### PR TITLE
Alterar máscara de coordenadas de formulário de fornecedor para aceitar um dígito antes do divisor #2

### DIFF
--- a/src/views/addresses/address-fields.vue
+++ b/src/views/addresses/address-fields.vue
@@ -142,7 +142,7 @@
           require=false,
           :error="errors[errorPrefix + 'address.latitude']",
           placeholder="00.00000000",
-          :mask="{ mask: 'M00.00000000' }"
+          :mask="{ mask: 'M99.00000000' }"
         )
 
       .three.columns
@@ -154,7 +154,7 @@
           require=false,
           :error="errors[errorPrefix + 'address.longitude']",
           placeholder="00.00000000",
-          :mask="{ mask: 'M00.00000000' }"
+          :mask="{ mask: 'M99.00000000' }"
         )
 
     .row


### PR DESCRIPTION
Issue: https://github.com/SolucaoOnlineDeLicitacao/sol-supplier-frontend/issues/2

----

Testado no ambiente de QA

![image](https://user-images.githubusercontent.com/5757502/67113174-3870d400-f1af-11e9-8c28-cb46c82a414c.png)
