### PR TITLE
Correção da máscara dos campos de latitude e longitude

### DIFF
--- a/src/lib/mask.js/mask.js
+++ b/src/lib/mask.js/mask.js
@@ -39,7 +39,8 @@ const globals = {
     '9': { pattern: /\d/, optional: true },
     '#': { pattern: /\d/, recursive: true },
     'A': { pattern: /[a-zA-Z0-9]/ },
-    'S': { pattern: /[a-zA-Z]/ }
+    'S': { pattern: /[a-zA-Z]/ },
+    'M': { pattern: /[-+]/, optional: true }
     /* eslint-enable quote-props */
   },
   clearIfNotMatch: false


### PR DESCRIPTION
Issue: https://github.com/SolucaoOnlineDeLicitacao/sol-supplier-frontend/issues/7

---

Adicionado _pattern_ `M` nas regras da máscara para abranger `-` e `+` dos campos de latitude e longitude.

### Antes

![screenshot-localhost_9082-2020 11 09-11_46_07 (2)](https://user-images.githubusercontent.com/22406399/98680069-a6021c00-233f-11eb-91b6-ab679f5b3f2f.png)

### Depois

![screenshot-localhost_9082-2020 11 09-11_46_07 (3)](https://user-images.githubusercontent.com/22406399/98680089-adc1c080-233f-11eb-8783-ddf2fabcdb39.png)
